### PR TITLE
Fixed expand_level not working when the tree data is updated

### DIFF
--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -332,6 +332,10 @@
                   return branch.children = [];
                 }
               });
+              for_each_branch(function (b, level) {
+                b.level = level;
+                return b.expanded = b.level < expand_level;
+              });
               add_branch_to_list = function (level, branch, visible) {
                 var child, child_visible, tree_icon, _i, _len, _ref, _results;
                 if (branch.expanded == null) {


### PR DESCRIPTION
I discovered that if the tree data is changed after the initial render of the table, it won't auto-expand the tree based on the expand-level attribute. This fixes that.