### PR TITLE
fix doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example:
       {  field: "Description" },
       {
         field: "DemographicId",
-        displayName: "Demographic Id"
+        displayName: "Demographic Id",
 		sortable : true,
 		filterable : true
       },
@@ -99,7 +99,7 @@ Example:
       {
         field: "image",
         displayName: "Image",
-        cellTemplate: "<img ng-click="cellTemplateScope.click('example')" ng-src="{{ row.branch[col.field] }}" />",
+        cellTemplate: "<img ng-click='cellTemplateScope.click(\'example\')' ng-src='{{ row.branch[col.field] }}' />",
         cellTemplateScope: {
             click: function(data) {         // this works too: $scope.someMethod;
                 console.log(data);


### PR DESCRIPTION
Hello, 

I've just used your exemple, and find 2 typos errors in this page  
https://github.com/khan4019/tree-grid-directive/blob/master/README.md
that cause my js compiler to fail 

The problems are : 

* displayName: "Demographic Id"
without end comma 
fixed with 
displayName: "Demographic Id",

* cellTemplate: "<img ng-click="cellTemplateScope.click('example')" ng-src="{{ row.branch[col.field] }}" />",
with wrong escaping of "'
fixed with 
cellTemplate: "<img ng-click='cellTemplateScope.click(\'example\')' ng-src='{{ row.branch[col.field] }}' />",

