### PR TITLE
remove extra space between icon and text

### DIFF
--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -18,8 +18,7 @@
           "       ng-class=\"'level-' + {{ row.level }} + (row.branch.selected ? ' active':'')\" class=\"tree-grid-row\">\n" +
           "       <td><a ng-click=\"user_clicks_branch(row.branch)\"><i ng-class=\"row.tree_icon\"\n" +
           "              ng-click=\"row.branch.expanded = !row.branch.expanded\"\n" +
-          "              class=\"indented tree-icon\"></i>\n" +
-          "           </a><span class=\"indented tree-label\" ng-click=\"on_user_click(row.branch)\">\n" +
+          "              class=\"indented tree-icon\"></i></a><span class=\"indented tree-label\" ng-click=\"on_user_click(row.branch)\">\n" +
           "             {{row.branch[expandingProperty.field] || row.branch[expandingProperty]}}</span>\n" +
           "       </td>\n" +
           "       <td ng-repeat=\"col in colDefinitions\">\n" +


### PR DESCRIPTION
There is an extra white space between the icon and text in the expanding cell. When the cursor is over this cell, it looks like the underscore.

BTW: Please update your demo (http://khan4019.github.io/tree-grid-directive/test/treeGrid.html), for the old version it was OK.