### PR TITLE
Expanding fix and new feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ If you want more customization, you can use the following options:
         on-select     = "my_tree_handler(branch)"
         on-click      = "my_tree_handler(branch)"
         template-url  = "path/to/treegrid/template.html"
-        expand-level  = "2">
+        expand-level  = "2"
+        expand-to     = "expand_to">
     </tree-grid>
 
 **col_defs:** is an array of objects that allows you to customized column header.
@@ -85,11 +86,11 @@ Valid properties are:
 	                    you want to show images, for instance.
 	cellTemplateScope:  Used to pass the controllers methods you want to be
 	                    used inside the cell template.
-	sortable:  			The user can sort by the values of this field	
-	sortingType: 		The type of the field, for sorting or filtering purposes.
-						Possible values are "number", for numeric sorting, or
-						"string" for alphabetic sorting (this is the default)
-	filterable:			This field will be searched when filtering
+	sortable:           The user can sort by the values of this field	
+	sortingType:        The type of the field, for sorting or filtering purposes.
+	                    Possible values are "number", for numeric sorting, or
+	                    "string" for alphabetic sorting (this is the default)
+	filterable:         This field will be searched when filtering
 
 Example:
 
@@ -135,7 +136,9 @@ to provide a cellTemplate (but not a cellTemplateScope).
 
 **template-url:** URL for the custom template to be used.
 
-**expand-level:** depth of the tree, you want to expand while loading.
+**expand-level:** depth of the tree, you want to expand while loading - default now set to 0 i.e. tree entirely collapsed. Note that you cannot collapse the tree below this depth, once set.
+
+**expand-to:** the `$rootscope` field the directive will watch for programmatic expansion. When changed, the directive will search the tree for the expandingproperty with the same value, and expand the tree to that point. All other branches will be collapsed.
 
 **on-select:** a click handler while you are clicking on +/- icons.
 

--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -87,7 +87,8 @@
                         onSelect: '&',
                         onClick: '&',
                         initialSelection: '@',
-                        treeControl: '='
+                        treeControl: '=',
+                        expandTo: '='
                     },
                     link: function (scope, element, attrs) {
                         var error, expandingProperty, expand_all_parents, expand_level, for_all_ancestors, for_each_branch, get_parent, n, on_treeData_change, select_branch, selected_branch, tree;
@@ -103,7 +104,7 @@
                         attrs.iconLeaf = attrs.iconLeaf ? attrs.iconLeaf : 'icon-file  glyphicon glyphicon-file  fa fa-file';
                         attrs.sortedAsc = attrs.sortedAsc ? attrs.sortedAsc : 'icon-file  glyphicon glyphicon-chevron-up  fa angle-up';
                         attrs.sortedDesc = attrs.sortedDesc ? attrs.sortedDesc : 'icon-file  glyphicon glyphicon-chevron-down  fa angle-down';
-                        attrs.expandLevel = attrs.expandLevel ? attrs.expandLevel : '3';
+                        attrs.expandLevel = attrs.expandLevel ? attrs.expandLevel : '0';
                         expand_level = parseInt(attrs.expandLevel, 10);
 
                         if (!scope.treeData) {
@@ -407,6 +408,21 @@
                         };
 
                         scope.$watch('treeData', on_treeData_change, true);
+
+                        on_expandTo_change = function () {
+                            if (angular.isDefined((scope.expandTo))) {
+                                for_each_branch(function (b) {
+                                    b.expanded = false;
+                                    if (b[expandingProperty.field] === scope.expandTo || b[expandingProperty] === scope.expandTo) {
+                                        return $timeout(function () {
+                                            return select_branch(b);
+                                        });
+                                    }
+                                });
+                            }
+                        };
+
+                        scope.$watch('expandTo', on_expandTo_change, true);
 
                         if (attrs.initialSelection != null) {
                             for_each_branch(function (b) {

--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -397,6 +397,10 @@
                                     return _results;
                                 }
                             };
+                            for_each_branch(function (b, level) {
+                                b.level = level;
+                                return b.expanded = b.level < expand_level;
+                            });
                             _ref = scope.treeData;
                             _results = [];
                             for (_i = 0, _len = _ref.length; _i < _len; _i++) {

--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -391,16 +391,12 @@
                                     _results = [];
                                     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
                                         child = _ref[_i];
-                                        child_visible = visible && branch.expanded;
+                                        child_visible = visible && (branch.expanded || branch.level < expand_level);
                                         _results.push(add_branch_to_list(level + 1, child, child_visible));
                                     }
                                     return _results;
                                 }
                             };
-                            for_each_branch(function (b, level) {
-                                b.level = level;
-                                return b.expanded = b.level < expand_level;
-                            });
                             _ref = scope.treeData;
                             _results = [];
                             for (_i = 0, _len = _ref.length; _i < _len; _i++) {


### PR DESCRIPTION
This pull request contains:

Fix for #84  - ensuring expand-level is respected when tree_data is loaded dynamically. This has a side-effect of ensuring the tree cannot be collapsed below this initial starting level, which may not be optimal. Any advice on how to achieve this would be welcome.

New feature - allow the dev to programmatically expand the tree to a certain node, by passing the expandingproperty value of that node into a $rootscope variable which the directive watches. Again, there may be a better way of doing this than using $rootscope, and if so any advice would be welcome.