### PR TITLE
tree_icon improvement 

### DIFF
--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -102,6 +102,7 @@
                         attrs.iconExpand = attrs.iconExpand ? attrs.iconExpand : 'icon-plus  glyphicon glyphicon-plus  fa fa-plus';
                         attrs.iconCollapse = attrs.iconCollapse ? attrs.iconCollapse : 'icon-minus glyphicon glyphicon-minus fa fa-minus';
                         attrs.iconLeaf = attrs.iconLeaf ? attrs.iconLeaf : 'icon-file  glyphicon glyphicon-file  fa fa-file';
+                        attrs.iconRoot = attrs.iconRoot ? attrs.iconRoot : '';
                         attrs.sortedAsc = attrs.sortedAsc ? attrs.sortedAsc : 'icon-file  glyphicon glyphicon-chevron-up  fa angle-up';
                         attrs.sortedDesc = attrs.sortedDesc ? attrs.sortedDesc : 'icon-file  glyphicon glyphicon-chevron-down  fa angle-down';
                         attrs.expandLevel = attrs.expandLevel ? attrs.expandLevel : '0';
@@ -371,7 +372,11 @@
                                     branch.expanded = false;
                                 }
                                 if (!branch.children || branch.children.length === 0) {
-                                    tree_icon = branch.icons && branch.icons.iconLeaf || attrs.iconLeaf;
+                                    if ((branch.icons && branch.icons.iconRoot || attrs.iconRoot) && branch.parent_uid == null) {
+                                        tree_icon = branch.icons && branch.icons.iconRoot || attrs.iconRoot;
+                                    } else {
+                                        tree_icon = branch.icons && branch.icons.iconLeaf || attrs.iconLeaf;
+                                    }
                                 } else {
                                     if (branch.expanded) {
                                         tree_icon = branch.icons && branch.icons.iconCollapse || attrs.iconCollapse;

--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -16,7 +16,7 @@
                     "   <tbody>\n" +
                     "     <tr ng-repeat=\"row in tree_rows | searchFor:$parent.filterString:expandingProperty:colDefinitions track by row.branch.uid\"\n" +
                     "       ng-class=\"'level-' + {{ row.level }} + (row.branch.selected ? ' active':'')\" class=\"tree-grid-row\">\n" +
-                    "       <td><a ng-click=\"user_clicks_branch(row.branch)\"><i ng-class=\"row.tree_icon\"\n" +
+                    "       <td><a ng-if=\"row.tree_icon && row.tree_icon !== 'null'\" ng-click=\"user_clicks_branch(row.branch)\"><i ng-class=\"row.tree_icon\"\n" +
                     "              ng-click=\"row.branch.expanded = !row.branch.expanded\"\n" +
                     "              class=\"indented tree-icon\"></i></a><span ng-if=\"expandingProperty.cellTemplate\" class=\"indented tree-label\" " +
                     "              ng-click=\"on_user_click(row.branch)\" compile=\"expandingProperty.cellTemplate\"></span>" +
@@ -72,7 +72,7 @@
             '$timeout',
             'treegridTemplate',
             function ($timeout,
-                      treegridTemplate) {
+                treegridTemplate) {
 
                 return {
                     restrict: 'E',


### PR DESCRIPTION
Hello there,

I am using this library for a work project and found improvements that are useful to me, so maybe you'll find them useful for others.

First, I find out you can write `icon-leaf="null"` to have no icon for leaves. So I removed the link when there is no icon. (https://github.com/khan4019/tree-grid-directive/commit/997c0b01fda22f8b5458df2a3aa666fe59a6d89a) 

Then, I added the possibility to have an icon for the roots. (https://github.com/khan4019/tree-grid-directive/commit/37da0272c964aa5847ce7065c6a02e3e4345b3e8)
In my project, the children are loaded after a server-side request, so I need to have an icon for the roots regardless if they have any children. When clicked it will send the request.

Thanks for reviewing my pull request. ;)